### PR TITLE
follow Dist::Zilla v6 change

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,6 @@
 requires 'perl', '5.008001';
 requires 'Dist::Zilla', '4.300030';
+requires 'Path::Tiny', '0.053';
 
 on test => sub {
     requires 'Test::More', '0.88';

--- a/lib/Dist/Zilla/Plugin/NameFromDirectory.pm
+++ b/lib/Dist/Zilla/Plugin/NameFromDirectory.pm
@@ -5,15 +5,19 @@ our $VERSION = '0.03';
 use Moose;
 with 'Dist::Zilla::Role::NameProvider';
 
-use Path::Class;
+use Path::Tiny ();
 
 sub provide_name {
     my $self = shift;
 
     my $root = $self->zilla->root->absolute;
 
+    # Dist::Zilla v6 has excised Path::Class in favor of Path::Tiny
+    # make sure $root is a Path::Tiny object
+    $root = Path::Tiny->new("$root");
+
     # make sure it is a root dir, by checking -e dist.ini
-    return unless -e $root->file('dist.ini');
+    return unless $root->child('dist.ini')->exists;
 
     my $name = $root->basename;
     $name =~ s/(?:^(?:perl|p5)-|[\-\.]pm$)//x;


### PR DESCRIPTION
Dist::Zilla v6 has excised Path::Class in favor of Path::Tiny.
See https://metacpan.org/release/RJBS/Dist-Zilla-6.000-TRIAL

Dist::Zilla v6 breaks Dist::Zilla::Plugin::NameFromDirectory:

```
> dzil --version
dzil (Dist::Zilla::App) version 6.001 (/Users/skaji/env/plenv/versions/relocatable-5.22.1.0/bin/dzil)
> milla new Foo
[DZ] making target dir /Users/skaji/Foo
[DZ] writing files to /Users/skaji/Foo
[Git::Init] Initializing a new git repository in /Users/skaji/Foo
[Milla::FirstBuild] Running the initial build & clean
Can't locate object method "file" via package "Path::Tiny" at /Users/skaji/env/plenv/versions/relocatable-5.22.1.0/lib/site_perl/5.22.1/Dist/Zilla/Plugin/NameFromDirectory.pm line 16.
```

This PR would fix this.

Note: I confirmed that tests passed with both Dist::Zilla v5 and v6.

```
> cpanm -nq --reinstall -llocal5 Dist::Zilla@5.046
Successfully installed Dist-Zilla-5.046 (downgraded from 6.001)
1 distribution installed
> cpanm -nq --reinstall -llocal6 Dist::Zilla@6.001
Successfully reinstalled Dist-Zilla-6.001
1 distribution installed

> prove -l -Ilocal5/lib/perl5 t
t/dir.t .. ok
All tests successful.
Files=1, Tests=1,  0 wallclock secs ( 0.02 usr  0.00 sys +  0.66 cusr  0.04 csys =  0.72 CPU)
Result: PASS
> prove -l -Ilocal6/lib/perl5 t
t/dir.t .. ok
All tests successful.
Files=1, Tests=1,  1 wallclock secs ( 0.01 usr  0.00 sys +  0.59 cusr  0.03 csys =  0.63 CPU)
Result: PASS
```
